### PR TITLE
GHI-4: Support "Not" policy elements

### DIFF
--- a/src/main/kotlin/com/github/lewisod/aws/dsl/JsonEncoder.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/JsonEncoder.kt
@@ -3,7 +3,7 @@ package com.github.lewisod.aws.dsl
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
 
-object JsonEncoder {
+internal object JsonEncoder {
     private val encoder = Json {
         encodeDefaults = false
     }

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/NegatablePolicyElement.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/NegatablePolicyElement.kt
@@ -4,4 +4,4 @@ data class NegatablePolicyElement<T>(val value: T, val isNegated: Boolean = fals
 
 typealias PrincipalElement = NegatablePolicyElement<Principal>
 typealias ActionElement = NegatablePolicyElement<List<String>>
-typealias ResourceElement = NegatablePolicyElement<String>
+typealias ResourceElement = NegatablePolicyElement<List<String>>

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/NegatablePolicyElement.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/NegatablePolicyElement.kt
@@ -1,0 +1,7 @@
+package com.github.lewisod.aws.dsl
+
+data class NegatablePolicyElement<T>(val value: T, val isNegated: Boolean = false)
+
+typealias PrincipalElement = NegatablePolicyElement<Principal>
+typealias ActionElement = NegatablePolicyElement<List<String>>
+typealias ResourceElement = NegatablePolicyElement<String>

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/Policy.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/Policy.kt
@@ -34,7 +34,7 @@ class PolicyBuilder internal constructor() {
      * @return A [Statement] instance, as defined by [statementBuilderBlock]
      * @throws InvalidStatementException
      */
-    fun statement(sid: String, statementBuilderBlock: StatementBuilder.() -> Unit) {
+    fun statement(sid: String? = null, statementBuilderBlock: StatementBuilder.() -> Unit) {
         val statementBuilder = StatementBuilder()
         statementBuilderBlock.invoke(statementBuilder)
         this.statements.add(statementBuilder.build(sid))

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/Policy.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/Policy.kt
@@ -20,6 +20,7 @@ data class Policy internal constructor(
  */
 fun Policy.toJson(): String = JsonEncoder.serialize(Policy.serializer(), this)
 
+@PolicyElementBuilder
 class PolicyBuilder internal constructor() {
 
     private var statements = mutableListOf<Statement>()

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/PolicyElementBuilder.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/PolicyElementBuilder.kt
@@ -1,0 +1,4 @@
+package com.github.lewisod.aws.dsl
+
+@DslMarker
+annotation class PolicyElementBuilder

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/Principal.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/Principal.kt
@@ -20,7 +20,7 @@ enum class PrincipalType(val textValue: String) {
 @Serializable(with = PrincipalSerializer::class)
 data class Principal internal constructor(
     val type: PrincipalType,
-    val values: List<String>
+    val principalIds: List<String>
 )
 
 private object PrincipalSerializer : KSerializer<Principal> {
@@ -29,10 +29,10 @@ private object PrincipalSerializer : KSerializer<Principal> {
         val descriptorIndex: Int = getIndexForType(value.type)
 
         val composite = encoder.beginStructure(descriptor)
-        if (value.values.size > 1) {
-            composite.encodeSerializableElement(descriptor, descriptorIndex, ListSerializer(String.serializer()), value.values)
+        if (value.principalIds.size > 1) {
+            composite.encodeSerializableElement(descriptor, descriptorIndex, ListSerializer(String.serializer()), value.principalIds)
         } else {
-            composite.encodeStringElement(descriptor, descriptorIndex, value.values.first())
+            composite.encodeStringElement(descriptor, descriptorIndex, value.principalIds.first())
         }
         composite.endStructure(descriptor)
     }
@@ -57,6 +57,7 @@ private object PrincipalSerializer : KSerializer<Principal> {
 
 fun Principal.toJson(): String = JsonEncoder.serialize(Principal.serializer(), this)
 
+@PolicyElementBuilder
 class PrincipalBuilder internal constructor() {
 
     private var type: PrincipalType? = null

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/Statement.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/Statement.kt
@@ -15,11 +15,14 @@ enum class Effect {
  */
 @Serializable
 data class Statement internal constructor(
-    @SerialName("Sid") val sid: String,
+    @SerialName("Sid") val sid: String? = null,
     @SerialName("Effect") val effect: Effect,
     @SerialName("Principal") val principal: Principal? = null,
-    @SerialName("Action") val action: List<String>,
-    @SerialName("Resource") val resource: String? = null
+    @SerialName("NotPrincipal") val notPrincipal: Principal? = null,
+    @SerialName("Action") val action: List<String> = listOf(),
+    @SerialName("NotAction") val notAction: List<String> = listOf(),
+    @SerialName("Resource") val resource: String? = null,
+    @SerialName("NotResource") val notResource: String? = null
 )
 
 /**
@@ -31,34 +34,74 @@ class StatementBuilder internal constructor() {
 
     private var effect: Effect? = null
     private val actions = mutableListOf<String>()
+    private val notActions = mutableListOf<String>()
     private var resource: String? = null
+    private var notResource: String? = null
     private var principal: Principal? = null
+    private var notPrincipal: Principal? = null
 
     /**
-     * Sets the [effect](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html) field
+     * Sets the [Effect](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_effect.html) field
      * of the statement
      */
-    fun effect(effect: Effect) { this.effect = effect }
+    fun effect(effect: Effect) {
+        if (this.effect != null) {
+            throw InvalidStatementException("A statement can only specify one Effect")
+        }
+        this.effect = effect
+    }
 
     /**
-     * Sets the [action](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html) field
+     * Sets the [Action](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html) field
      * of the statement
      */
-    fun action(vararg actions: String) { this.actions.addAll(actions) }
+    fun action(vararg actions: String) {
+        if (this.notActions.isNotEmpty()) {
+            throw InvalidStatementException("A statement can only specify one of Action or NotAction")
+        }
+        this.actions.addAll(actions)
+    }
 
     /**
-     * Sets the [resource](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html)
+     * Sets the [NotAction](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html)
      * field of the statement
      */
-    fun resource(resource: String) { this.resource = resource }
+    fun notAction(vararg actions: String) {
+        if (this.actions.isNotEmpty()) {
+            throw InvalidStatementException("A statement can only specify one of Action or NotAction")
+        }
+        this.notActions.addAll(actions)
+    }
 
     /**
-     * Sets the [principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
+     * Sets the [Resource](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html)
+     * field of the statement
+     */
+    fun resource(resource: String) {
+        if (this.notResource != null) {
+            throw InvalidStatementException("A statement can only specify one of Resource or NotResource")
+        }
+        this.resource = resource
+    }
+
+    /**
+     * Sets the [NotResource](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html)
+     * field of the statement
+     */
+    fun notResource(resource: String) {
+        if (this.resource != null) {
+            throw InvalidStatementException("A statement can only specify one of Resource or NotResource")
+        }
+        this.notResource = resource
+    }
+
+    /**
+     * Sets the [Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
      * field of the statement
      */
     fun principal(principalBuilderBlock: PrincipalBuilder.() -> Unit) {
-        if (this.principal != null) {
-            throw InvalidStatementException("A statement can only have one policy")
+        if (this.principal != null || this.notPrincipal != null) {
+            throw InvalidStatementException("A statement can only specify one Principal")
         }
 
         val builder = PrincipalBuilder()
@@ -66,17 +109,34 @@ class StatementBuilder internal constructor() {
         this.principal = builder.build()
     }
 
-    internal fun build(sid: String): Statement {
+    /**
+     * Sets the [NotPrincipal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html)
+     * field of the statement
+     */
+    fun notPrincipal(principalBuilderBlock: PrincipalBuilder.() -> Unit) {
+        if (this.principal != null || this.notPrincipal != null) {
+            throw InvalidStatementException("A statement can only specify one Principal")
+        }
+
+        val builder = PrincipalBuilder()
+        principalBuilderBlock.invoke(builder)
+        this.principal = builder.build()
+    }
+
+    internal fun build(sid: String?): Statement {
         if (actions.isEmpty()) {
-            throw InvalidStatementException("A statement must contain at least 1 action")
+            throw InvalidStatementException("A statement must contain at least 1 Action")
         }
 
         return Statement(
             sid,
             effect ?: throw InvalidStatementException("Statement must specify an effect"),
             principal,
+            notPrincipal,
             Collections.unmodifiableList(actions),
-            resource
+            Collections.unmodifiableList(notActions),
+            resource,
+            notResource
         )
     }
 }

--- a/src/main/kotlin/com/github/lewisod/aws/dsl/Statement.kt
+++ b/src/main/kotlin/com/github/lewisod/aws/dsl/Statement.kt
@@ -30,6 +30,7 @@ data class Statement internal constructor(
  */
 fun Statement.toJson(): String = JsonEncoder.serialize(Statement.serializer(), this)
 
+@PolicyElementBuilder
 class StatementBuilder internal constructor() {
 
     private var effect: Effect? = null
@@ -122,6 +123,8 @@ class StatementBuilder internal constructor() {
         principalBuilderBlock.invoke(builder)
         this.principal = builder.build()
     }
+
+    fun build(): Statement = build(null)
 
     internal fun build(sid: String?): Statement {
         if (actions.isEmpty()) {

--- a/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
+++ b/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
@@ -12,7 +12,7 @@ internal class PolicyTest {
             Effect.ALLOW,
             action = ActionElement(listOf("action")),
             sid = "sid",
-            resource = ResourceElement("resource"))
+            resource = ResourceElement(listOf("resource")))
         val expectedPolicy = Policy("version", listOf(statement))
 
         val policy = policy("version") {
@@ -32,7 +32,7 @@ internal class PolicyTest {
             Effect.ALLOW,
             action = ActionElement(listOf("action")),
             sid = "sid",
-            resource = ResourceElement("resource"))
+            resource = ResourceElement(listOf("resource")))
         val expectedPolicy = Policy("2012-10-17", listOf(statement))
 
         val policy = policy {
@@ -52,7 +52,7 @@ internal class PolicyTest {
             Effect.ALLOW,
             action = ActionElement(listOf("action")),
             sid = "sid",
-            resource = ResourceElement("resource"))
+            resource = ResourceElement(listOf("resource")))
         val policy = Policy("2012-10-17", listOf(statement))
 
         val expectedJson = """

--- a/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
+++ b/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
@@ -8,7 +8,11 @@ internal class PolicyTest {
 
     @Test
     fun `Builds a policy with the specified version`() {
-        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
+        val statement = Statement(
+            Effect.ALLOW,
+            action = ActionElement(listOf("action")),
+            sid = "sid",
+            resource = ResourceElement("resource"))
         val expectedPolicy = Policy("version", listOf(statement))
 
         val policy = policy("version") {
@@ -24,7 +28,11 @@ internal class PolicyTest {
 
     @Test
     fun `Builds a policy with the default version`() {
-        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
+        val statement = Statement(
+            Effect.ALLOW,
+            action = ActionElement(listOf("action")),
+            sid = "sid",
+            resource = ResourceElement("resource"))
         val expectedPolicy = Policy("2012-10-17", listOf(statement))
 
         val policy = policy {
@@ -40,7 +48,11 @@ internal class PolicyTest {
 
     @Test
     fun `Serializes to JSON correctly`() {
-        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
+        val statement = Statement(
+            Effect.ALLOW,
+            action = ActionElement(listOf("action")),
+            sid = "sid",
+            resource = ResourceElement("resource"))
         val policy = Policy("2012-10-17", listOf(statement))
 
         val expectedJson = """
@@ -50,7 +62,7 @@ internal class PolicyTest {
                 {
                   "Sid": "sid",
                   "Effect": "Allow",
-                  "Action": ["action"],
+                  "Action": "action",
                   "Resource": "resource"
                 }
               ]

--- a/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
+++ b/src/test/kotlin/com/github/lewisod/aws/dsl/PolicyTest.kt
@@ -8,7 +8,7 @@ internal class PolicyTest {
 
     @Test
     fun `Builds a policy with the specified version`() {
-        val statement = Statement("sid", Effect.ALLOW, null, listOf("action"), "resource")
+        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
         val expectedPolicy = Policy("version", listOf(statement))
 
         val policy = policy("version") {
@@ -24,7 +24,7 @@ internal class PolicyTest {
 
     @Test
     fun `Builds a policy with the default version`() {
-        val statement = Statement("sid", Effect.ALLOW, null, listOf("action"), "resource")
+        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
         val expectedPolicy = Policy("2012-10-17", listOf(statement))
 
         val policy = policy {
@@ -40,7 +40,7 @@ internal class PolicyTest {
 
     @Test
     fun `Serializes to JSON correctly`() {
-        val statement = Statement("sid", Effect.ALLOW, null, listOf("action"), "resource")
+        val statement = Statement("sid", Effect.ALLOW, action = listOf("action"), resource = "resource")
         val policy = Policy("2012-10-17", listOf(statement))
 
         val expectedJson = """

--- a/src/test/kotlin/com/github/lewisod/aws/dsl/StatementTest.kt
+++ b/src/test/kotlin/com/github/lewisod/aws/dsl/StatementTest.kt
@@ -2,39 +2,44 @@ package com.github.lewisod.aws.dsl
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 
 internal class StatementTest {
 
+    private var builder = StatementBuilder()
+
+    @BeforeEach
+    fun beforeEach() {
+        builder = StatementBuilder()
+    }
+
     @Test
     fun `Builds a statement when provided with a valid configuration`() {
-        val builder = StatementBuilder()
         builder.resource("resource")
         builder.effect(Effect.ALLOW)
         builder.action("action1")
         builder.action("action2")
         val builtStatement = builder.build("sid")
 
-        val expectedStatement = Statement("sid", Effect.ALLOW, null, listOf("action1", "action2"), "resource")
+        val expectedStatement = Statement("sid", Effect.ALLOW, action = listOf("action1", "action2"), resource = "resource")
         assertThat(builtStatement).isEqualToComparingFieldByField(expectedStatement)
     }
 
     @Test
     fun `Throws an exception when no actions supplied`() {
-        val builder = StatementBuilder()
         builder.resource("resource")
         builder.effect(Effect.ALLOW)
 
         assertThatThrownBy {
             builder.build("sid")
         }.isInstanceOf(InvalidStatementException::class.java)
-            .hasMessageContaining("A statement must contain at least 1 action")
+            .hasMessageContaining("A statement must contain at least 1 Action")
     }
 
     @Test
     fun `Throws an exception when effect is not provided`() {
-        val builder = StatementBuilder()
         builder.resource("resource")
         builder.action("action")
 
@@ -45,22 +50,72 @@ internal class StatementTest {
     }
 
     @Test
-    fun `Throws an exception two principals are provided`() {
-        val builder = StatementBuilder()
-        builder.principal {
-            aws("account-1")
-        }
-        assertThatThrownBy {
-            builder.principal {
-                aws("account-2")
-            }
-        }.isInstanceOf(InvalidStatementException::class.java)
-            .hasMessageContaining("A statement can only have one policy")
+    fun `Throws an exception on conflicting NotAction`() {
+        builder.action("action")
+        assertThatThrownBy { builder.notAction("action") }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one of Action or NotAction")
     }
 
     @Test
-    fun `With no principal serializes to JSON correctly`() {
-        val statement = Statement("sid", Effect.ALLOW, null, listOf("action1", "action2"), "resource")
+    fun `Throws an exception on conflicting Action`() {
+        builder.notAction("action")
+        assertThatThrownBy { builder.action("action") }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one of Action or NotAction")
+    }
+
+    @Test
+    fun `Throws an exception on conflicting NotResource`() {
+        builder.resource("resource")
+        assertThatThrownBy { builder.notResource("resource") }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one of Resource or NotResource")
+    }
+
+    @Test
+    fun `Throws an exception on conflicting Resource`() {
+        builder.notResource("resource")
+        assertThatThrownBy { builder.resource("resource") }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one of Resource or NotResource")
+    }
+
+    @Test
+    fun `Throws an exception on conflicting NotPrincipal`() {
+        builder.principal { aws("arn") }
+        assertThatThrownBy { builder.notPrincipal { aws("arn") } }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one Principal")
+    }
+
+    @Test
+    fun `Throws an exception on conflicting Principal`() {
+        builder.notPrincipal { aws("arn") }
+        assertThatThrownBy { builder.principal { aws("arn") } }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one Principal")
+    }
+
+    @Test
+    fun `Throws an exception two Principals are provided`() {
+        builder.principal { aws("account-1") }
+        assertThatThrownBy { builder.principal { aws("account-2") } }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one Principal")
+    }
+
+    @Test
+    fun `Throws an exception two NotPrincipals are provided`() {
+        builder.notPrincipal { aws("account-1") }
+        assertThatThrownBy { builder.notPrincipal { aws("account-2") } }
+            .isInstanceOf(InvalidStatementException::class.java)
+            .hasMessageContaining("A statement can only specify one Principal")
+    }
+
+    @Test
+    fun `With no Principal serializes to JSON correctly`() {
+        val statement = Statement("sid", Effect.ALLOW, action = listOf("action1", "action2"), resource = "resource")
         val expectedJson = """
             {
               "Sid": "sid",
@@ -78,7 +133,7 @@ internal class StatementTest {
     @Test
     fun `With no resource serializes to JSON correctly`() {
         val principal = Principal(PrincipalType.AWS, listOf("account"))
-        val statement = Statement("sid", Effect.ALLOW, principal, listOf("action1", "action2"), null)
+        val statement = Statement("sid", Effect.ALLOW, principal =  principal, action = listOf("action1", "action2"))
         val expectedJson = """
             {
               "Sid": "sid",

--- a/src/test/kotlin/com/github/lewisod/aws/dsl/StatementTest.kt
+++ b/src/test/kotlin/com/github/lewisod/aws/dsl/StatementTest.kt
@@ -27,7 +27,7 @@ internal class StatementTest {
             Effect.ALLOW,
             action = ActionElement(listOf("action1", "action2")),
             sid = "sid",
-            resource = ResourceElement("resource")
+            resource = ResourceElement(listOf("resource"))
         )
         assertThat(builtStatement).isEqualToComparingFieldByField(expectedStatement)
     }
@@ -75,7 +75,7 @@ internal class StatementTest {
         builder.resource("resource")
         assertThatThrownBy { builder.notResource("resource") }
             .isInstanceOf(InvalidStatementException::class.java)
-            .hasMessageContaining("A statement can only specify one Resource")
+            .hasMessageContaining("A statement can only specify either Resource or NotResource")
     }
 
     @Test
@@ -83,7 +83,7 @@ internal class StatementTest {
         builder.notResource("resource")
         assertThatThrownBy { builder.resource("resource") }
             .isInstanceOf(InvalidStatementException::class.java)
-            .hasMessageContaining("A statement can only specify one Resource")
+            .hasMessageContaining("A statement can only specify either Resource or NotResource")
     }
 
     @Test
@@ -144,7 +144,7 @@ internal class StatementTest {
             Effect.ALLOW,
             action = ActionElement(listOf("action1", "action2")),
             sid = "sid",
-            resource = ResourceElement("resource")
+            resource = ResourceElement(listOf("resource"))
         )
         val expectedJson = """
             {
@@ -191,7 +191,7 @@ internal class StatementTest {
             action = ActionElement(listOf("action1", "action2"), isNegated = true),
             sid = "sid",
             principal = PrincipalElement(principal, isNegated = true),
-            resource = ResourceElement("resource", isNegated = true)
+            resource = ResourceElement(listOf("resource"), isNegated = true)
         )
         val expectedJson = """
             {
@@ -200,6 +200,29 @@ internal class StatementTest {
               "NotAction": ["action1", "action2"],
               "NotPrincipal": { "AWS": "account" },
               "NotResource": "resource"
+            }
+        """.trimIndent()
+
+        val actualJson = statement.toJson()
+
+        JSONAssert.assertEquals(expectedJson, actualJson, true)
+    }
+
+    @Test
+    fun `With multiple Resources serializes to JSON correctly`() {
+        val principal = Principal(PrincipalType.AWS, listOf("account"))
+        val statement = Statement(
+            Effect.ALLOW,
+            action = ActionElement(listOf("action1", "action2")),
+            sid = "sid",
+            resource = ResourceElement(listOf("resource1", "resource2"))
+        )
+        val expectedJson = """
+            {
+              "Sid": "sid",
+              "Effect": "Allow",
+              "Action": ["action1", "action2"],
+              "Resource": ["resource1", "resource2"]
             }
         """.trimIndent()
 


### PR DESCRIPTION
- Add support for "Not" policy elements
- Add `@DslMarker` annotation to fix scope issues in builders
- Add support for multiple resources in a Resource element

Closes #4 